### PR TITLE
Update navigator-mixin.js

### DIFF
--- a/src/view/frontend/web/js/mixin/navigator-mixin.js
+++ b/src/view/frontend/web/js/mixin/navigator-mixin.js
@@ -18,14 +18,14 @@ define([
             if (customer.isLoggedIn() && code === 'email') {
                 return;
             }
-            var sortedItems = target.steps.sort(this.sortItems);
+            var sortedItems = target.steps().sort(this.sortItems);
             if (!this.isProcessed(code)) {
                 return;
             }
 
             window.location = window.checkoutConfig.checkoutUrl + '#' + code;
             sortedItems.forEach(function (element) {
-                element.isVisible(element.code === code);
+                element.isVisible(element.code == code); //eslint-disable-line eqeqeq
             });
         };
 
@@ -50,7 +50,7 @@ define([
                 return false;
             }
 
-            isRequestedStepVisible = target.steps.sort(this.sortItems).some(function (element) {
+            isRequestedStepVisible = target.steps().sort(this.sortItems).some(function (element) {
                 return (element.code == hashString || element.alias == hashString) && element.isVisible(); //eslint-disable-line
             });
 
@@ -59,7 +59,7 @@ define([
                 return false;
             }
 
-            target.steps.sort(this.sortItems).forEach(function (element) {
+            target.steps().sort(this.sortItems).forEach(function (element) {
                 if (element.code == hashString || element.alias == hashString) { //eslint-disable-line eqeqeq
                     element.navigate(element);
                 } else {


### PR DESCRIPTION
steps is an observable knockout array; and knockout did some change on it behaviour 
function to return the `observableArray` instead of the `Array` (https://github.com/knockout/knockout/pull/1380)

This pull request modify calling variable steps.

due to the core change in Magento_Checkout :
https://github.com/magento/magento2/commit/216b595d69f601019779ca57e446d7c904f89175#diff-0dc39b1aa23d2947af8f85bd04c2d603